### PR TITLE
Feat/login status

### DIFF
--- a/lang/en/theme_saylor.php
+++ b/lang/en/theme_saylor.php
@@ -96,6 +96,12 @@ $string['market3desc'] = 'Add html for marketing block 3 (see the readme file fo
 $string['market4'] = 'Marketing Block 4';
 $string['market4desc'] = 'Add html for marketing block 4 (see the readme file for additional info and hints).';
 
+$string['logintext'] = 'Log in';
+$string['loggedingreeting'] = 'Hi, {$a}!';
+$string['loggedinnotgreeting'] = '';
+
+$string['logouttext'] = 'Log out';
+
 $string['logo'] = 'Logo';
 $string['logodesc'] = 'Change the logo of this theme by entering the URL to a new one (i.e., http://www.somesite/animage.png). A transparent .png will work best.';
 

--- a/renderers.php
+++ b/renderers.php
@@ -109,7 +109,7 @@ class theme_saylor_core_renderer extends core_renderer
             } else {
                 $loggedinas = $realuserinfo.get_string('loggedingreeting', 'theme_saylor', $username);
                 if ($withlinks) {
-                    $loggedinas .= " <a href=\"$CFG->wwwroot/login/logout.php?sesskey=".sesskey()."\">".get_string('logouttext', 'theme_saylor').'</a>';
+                    $loggedinas .= " | <a href=\"$CFG->wwwroot/login/logout.php?sesskey=".sesskey()."\">".get_string('logouttext', 'theme_saylor').'</a>';
                 }
             }
         } else {

--- a/renderers.php
+++ b/renderers.php
@@ -33,6 +33,117 @@ require_once($CFG->dirroot . "/blocks/course_overview/renderer.php");
 class theme_saylor_core_renderer extends core_renderer
 {
 
+    /**
+     * Return the standard string that says whether you are logged in (and switched
+     * roles/logged in as another user).
+     * @param bool $withlinks if false, then don't include any links in the HTML produced.
+     * If not set, the default is the nologinlinks option from the theme config.php file,
+     * and if that is not set, then links are included.
+     * @return string HTML fragment.
+     */
+    public function login_info($withlinks = null) {
+        global $USER, $CFG, $DB, $SESSION;
+
+        if (during_initial_install()) {
+            return '';
+        }
+
+        if (is_null($withlinks)) {
+            $withlinks = empty($this->page->layout_options['nologinlinks']);
+        }
+
+        $course = $this->page->course;
+        if (\core\session\manager::is_loggedinas()) {
+            $realuser = \core\session\manager::get_realuser();
+            $fullname = fullname($realuser, true);
+            if ($withlinks) {
+                $loginastitle = get_string('loginas');
+                $realuserinfo = " [<a href=\"$CFG->wwwroot/course/loginas.php?id=$course->id&amp;sesskey=".sesskey()."\"";
+                $realuserinfo .= "title =\"".$loginastitle."\">$fullname</a>] ";
+            } else {
+                $realuserinfo = " [$fullname] ";
+            }
+        } else {
+            $realuserinfo = '';
+        }
+
+        $loginpage = $this->is_login_page();
+        $loginurl = get_login_url();
+
+        if (empty($course->id)) {
+            // $course->id is not defined during installation
+            return '';
+        } else if (isloggedin()) {
+            $context = context_course::instance($course->id);
+
+            $fullname = fullname($USER, true);
+            // Since Moodle 2.0 this link always goes to the public profile page (not the course profile page)
+            if ($withlinks) {
+                $linktitle = get_string('viewprofile');
+                $username = "<a href=\"$CFG->wwwroot/user/profile.php?id=$USER->id\" title=\"$linktitle\">$fullname</a>";
+            } else {
+                $username = $fullname;
+            }
+            if (is_mnet_remote_user($USER) and $idprovider = $DB->get_record('mnet_host', array('id'=>$USER->mnethostid))) {
+                if ($withlinks) {
+                    $username .= " from <a href=\"{$idprovider->wwwroot}\">{$idprovider->name}</a>";
+                } else {
+                    $username .= " from {$idprovider->name}";
+                }
+            }
+            if (isguestuser()) {
+                $loggedinas = get_string('loggedinnotgreeting', 'theme_saylor');
+                if (!$loginpage && $withlinks) {
+                    $loggedinas .= " <a href=\"$loginurl\">".get_string('logintext', 'theme_saylor').'</a>';
+                }
+            } else if (is_role_switched($course->id)) { // Has switched roles
+                $rolename = '';
+                if ($role = $DB->get_record('role', array('id'=>$USER->access['rsw'][$context->path]))) {
+                    $rolename = ': '.role_get_name($role, $context);
+                }
+                $loggedinas = get_string('loggedinas', 'moodle', $username).$rolename;
+                if ($withlinks) {
+                    $url = new moodle_url('/course/switchrole.php', array('id'=>$course->id,'sesskey'=>sesskey(), 'switchrole'=>0, 'returnurl'=>$this->page->url->out_as_local_url(false)));
+                    $loggedinas .= ' '.html_writer::tag('a', get_string('switchrolereturn'), array('href' => $url)).'';
+                }
+            } else {
+                $loggedinas = $realuserinfo.get_string('loggedingreeting', 'theme_saylor', $username);
+                if ($withlinks) {
+                    $loggedinas .= " <a href=\"$CFG->wwwroot/login/logout.php?sesskey=".sesskey()."\">".get_string('logouttext', 'theme_saylor').'</a>';
+                }
+            }
+        } else {
+            $loggedinas = get_string('loggedinnotgreeting', 'theme_saylor');
+            if (!$loginpage && $withlinks) {
+                $loggedinas .= " <a href=\"$loginurl\">".get_string('logintext', 'theme_saylor').'</a>';
+            }
+        }
+
+        $loggedinas = '<div class="logininfo">'.$loggedinas.'</div>';
+
+        if (isset($SESSION->justloggedin)) {
+            unset($SESSION->justloggedin);
+            if (!empty($CFG->displayloginfailures)) {
+                if (!isguestuser()) {
+                    // Include this file only when required.
+                    require_once($CFG->dirroot . '/user/lib.php');
+                    if ($count = user_count_login_failures($USER)) {
+                        $loggedinas .= '<div class="loginfailures">';
+                        $a = new stdClass();
+                        $a->attempts = $count;
+                        $loggedinas .= get_string('failedloginattempts', '', $a);
+                        if (file_exists("$CFG->dirroot/report/log/index.php") and has_capability('report/log:view', context_system::instance())) {
+                            $loggedinas .= ' ('.html_writer::link(new moodle_url('/report/log/index.php', array('chooselog' => 1,
+                                    'id' => 0 , 'modid' => 'site_errors')), get_string('logs')).')';
+                        }
+                        $loggedinas .= '</div>';
+                    }
+                }
+            }
+        }
+
+        return $loggedinas;
+    }
 
     public function user_menu($user = null, $withlinks = null) {
         global $CFG, $USER;

--- a/style/custom.css
+++ b/style/custom.css
@@ -613,17 +613,6 @@ input[type="color"],
     font-size: 20px;
 }
 
-/*Hide message and parentheses login status message on nav bar*/
-.logininfo {
-    margin-top: 5px;
-    visibility: hidden;
-}
-
-/*But still show the a href hyperlink text*/
-#page-header .socials a {
-visibility: visible;
-}
-
 @media (max-width: 979px) {
     .navbar {
         float: none !important;

--- a/style/custom.css
+++ b/style/custom.css
@@ -608,6 +608,20 @@ input[type="color"],
     display: none; 
 }
 
+/*Fix padding issue on left nav bar*/
+.block .content{
+    padding: 0.5em 1em !important;
+}
+
+/*Fix header padding issue on left nav bar*/
+.block .header {
+    padding: 0.5em !important;
+}
+
+/*Add bottom padding to each sub-block in central block content*/
+.format-flexsections .course-content ul.flexsections li.section {
+    padding-bottom: 0.5em;
+
 /*Increase font size of login status message on nav bar*/
 #page-header .socials {
     font-size: 20px;

--- a/style/custom.css
+++ b/style/custom.css
@@ -621,6 +621,7 @@ input[type="color"],
 /*Add bottom padding to each sub-block in central block content*/
 .format-flexsections .course-content ul.flexsections li.section {
     padding-bottom: 0.5em;
+}
 
 /*Increase font size of login status message on nav bar*/
 #page-header .socials {

--- a/style/custom.css
+++ b/style/custom.css
@@ -612,6 +612,11 @@ input[type="color"],
     display: none; 
 }
 
+/*Increase font size of login status message on nav bar*/
+#page-header .socials {
+    font-size: 20px;
+}
+
 @media (max-width: 979px) {
     .navbar {
         float: none !important;

--- a/style/custom.css
+++ b/style/custom.css
@@ -144,10 +144,6 @@ h2.main,
     margin: 0 auto;
 }
 
-.logininfo {
-    margin-top: 5px;
-}
-
 #page-header .logo-img {
     background-position: center center;
     background-repeat: no-repeat;
@@ -619,6 +615,7 @@ input[type="color"],
 
 /*Hide message and parentheses login status message on nav bar*/
 .logininfo {
+    margin-top: 5px;
     visibility: hidden;
 }
 

--- a/style/custom.css
+++ b/style/custom.css
@@ -617,6 +617,16 @@ input[type="color"],
     font-size: 20px;
 }
 
+/*Hide message and parentheses login status message on nav bar*/
+.logininfo {
+    visibility: hidden;
+}
+
+/*But still show the a href hyperlink text*/
+#page-header .socials a {
+visibility: visible;
+}
+
 @media (max-width: 979px) {
     .navbar {
         float: none !important;

--- a/version.php
+++ b/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2017060400;
+$plugin->version   = 2017060500;
 $plugin->requires  = 2014110400;
 $plugin->component = 'theme_saylor';


### PR DESCRIPTION
This should take care of part of #12 - Log in status message is now customizable in the language string file for our theme; implemented a custom login_info().

Not logged in/guest (user won't know they're a guest):
<img width="295" alt="screen shot 2017-07-15 at 10 42 41 pm" src="https://user-images.githubusercontent.com/6720891/28242891-f63338d2-69af-11e7-87d5-dfc063e483e0.png">

Logged in:
<img width="490" alt="screen shot 2017-07-15 at 10 40 55 pm" src="https://user-images.githubusercontent.com/6720891/28242894-06653d90-69b0-11e7-9626-5e3935ce26c7.png">

Admin logged in as another user:
<img width="483" alt="screen shot 2017-07-15 at 10 42 17 pm" src="https://user-images.githubusercontent.com/6720891/28242895-076beb9e-69b0-11e7-93c4-affc5087fe5e.png">

