### PR TITLE
add bottom padding to center block content

### DIFF
--- a/style/custom.css
+++ b/style/custom.css
@@ -612,6 +612,11 @@ input[type="color"],
     display: none; 
 }
 
+/*Add bottom padding to each sub-block in central block content*/
+.format-flexsections .course-content ul.flexsections li.section {
+    padding-bottom: 0.5em;
+}
+
 @media (max-width: 979px) {
     .navbar {
         float: none !important;


### PR DESCRIPTION
Fixed padding issue on central block by adding some bottom padding:

<img width="887" alt="screen shot 2017-07-17 at 10 22 12 am" src="https://user-images.githubusercontent.com/16823841/28272710-4e6b74d0-6ada-11e7-997f-61bbf1cf84a8.png">


