### PR TITLE
change string for login text in WP and Learn

### DIFF
--- a/lang/en/theme_saylor.php
+++ b/lang/en/theme_saylor.php
@@ -96,7 +96,7 @@ $string['market3desc'] = 'Add html for marketing block 3 (see the readme file fo
 $string['market4'] = 'Marketing Block 4';
 $string['market4desc'] = 'Add html for marketing block 4 (see the readme file for additional info and hints).';
 
-$string['logintext'] = 'Log in';
+$string['logintext'] = 'Log in or Sign up';
 $string['loggedingreeting'] = 'Hi, {$a}!';
 $string['loggedinnotgreeting'] = '';
 


### PR DESCRIPTION
Issue #56 resolved: 
<img width="422" alt="screen shot 2017-08-08 at 4 15 42 pm" src="https://user-images.githubusercontent.com/16823841/29093788-10958c6e-7c59-11e7-8914-f44050b7f576.png">
<img width="368" alt="screen shot 2017-08-08 at 4 42 44 pm" src="https://user-images.githubusercontent.com/16823841/29093793-13785d6c-7c59-11e7-87eb-e6fdf3125b36.png">
 