### PR TITLE
Round buttons

### DIFF
--- a/scss/preset/default.scss
+++ b/scss/preset/default.scss
@@ -180,7 +180,7 @@ $light:         $gray-100 !default;
 $dark:          $gray-600 !default;
 
 // Options
-$enable-rounded: false !default;
+$enable-rounded: true !default;
 
 // Body
 $body-color:    $gray-800 !default;


### PR DESCRIPTION
@rpmcdonnell Currently, enabling this option rounds _everything_ including all cards and text areas. Do we want to have those rounded out as well?
<img width="1330" alt="screen shot 2018-09-07 at 10 59 12 am" src="https://user-images.githubusercontent.com/6720891/45209362-19ee9880-b28d-11e8-85fe-907af222903c.png">
 