### PR TITLE
Feat/2018 highlight primary buttons

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -15,6 +15,10 @@ img.userpicture {
 	border-color: $gray-200;
 }
 
+.navbar .nav-link .fa-bars {
+	color: $dark;
+}
+
 // Change height, margin and padding of navbar logo.
 .navbar-brand .logo .icon {
     height: auto;

--- a/scss/post.scss
+++ b/scss/post.scss
@@ -10,6 +10,11 @@ img.userpicture {
     box-shadow: 0 3px 0 $primary;
 }
 
+.navbar .btn {
+	background-color: $gray-200;
+	border-color: $gray-200;
+}
+
 // Change height, margin and padding of navbar logo.
 .navbar-brand .logo .icon {
     height: auto;

--- a/scss/preset/default.scss
+++ b/scss/preset/default.scss
@@ -248,3 +248,13 @@ body {
 .usermenu {
     font-size: 1.2em;
 }
+
+// Button color should be our button orange.
+.btn-primary {
+    background-color: $button-bg-orange;
+    border-color: $button-bg-orange;
+}
+.btn-secondary {
+    background-color: $button-bg-orange;
+    border-color: $button-bg-orange;
+}


### PR DESCRIPTION
@rpmcdonnell 

This PR standardizes the color of primary and secondary buttons. The button-bg-orange looks different than the secondary color, though. Is that intended?

It also returns the nav-drawer toggle to a gray color so its not jarring.