### PR TITLE
Feat/2018 enroll button

### DIFF
--- a/config.php
+++ b/config.php
@@ -42,3 +42,113 @@ $THEME->scss = function($theme) {
     return theme_saylor_get_main_scss_content($theme);
 };
 
+$THEME->layouts = [
+    // Most backwards compatible layout without the blocks - this is the layout used by default.
+    'base' => array(
+        'file' => 'columns2.php',
+        'regions' => array(),
+    ),
+    // Standard layout with blocks, this is recommended for most pages with general information.
+    'standard' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // Main course page.
+    'course' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+        'options' => array('langmenu' => true),
+    ),
+    'coursecategory' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // Part of course, typical for modules - default page layout if $cm specified in require_login().
+    'incourse' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // The site home page.
+    'frontpage' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+        'options' => array('nonavbar' => true),
+    ),
+    // Server administration scripts.
+    'admin' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // My dashboard page.
+    'mydashboard' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+        'options' => array('nonavbar' => true, 'langmenu' => true),
+    ),
+    // My public page.
+    'mypublic' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    'login' => array(
+        'file' => 'login.php',
+        'regions' => array(),
+        'options' => array('langmenu' => true),
+    ),
+
+    // Pages that appear in pop-up windows - no navigation, no blocks, no header.
+    'popup' => array(
+        'file' => 'columns1.php',
+        'regions' => array(),
+        'options' => array('nofooter' => true, 'nonavbar' => true),
+    ),
+    // No blocks and minimal footer - used for legacy frame layouts only!
+    'frametop' => array(
+        'file' => 'columns1.php',
+        'regions' => array(),
+        'options' => array('nofooter' => true, 'nocoursefooter' => true),
+    ),
+    // Embeded pages, like iframe/object embeded in moodleform - it needs as much space as possible.
+    'embedded' => array(
+        'file' => 'embedded.php',
+        'regions' => array()
+    ),
+    // Used during upgrade and install, and for the 'This site is undergoing maintenance' message.
+    // This must not have any blocks, links, or API calls that would lead to database or cache interaction.
+    // Please be extremely careful if you are modifying this layout.
+    'maintenance' => array(
+        'file' => 'maintenance.php',
+        'regions' => array(),
+    ),
+    // Should display the content and basic headers only.
+    'print' => array(
+        'file' => 'columns1.php',
+        'regions' => array(),
+        'options' => array('nofooter' => true, 'nonavbar' => false),
+    ),
+    // The pagelayout used when a redirection is occuring.
+    'redirect' => array(
+        'file' => 'embedded.php',
+        'regions' => array(),
+    ),
+    // The pagelayout used for reports.
+    'report' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // The pagelayout used for safebrowser and securewindow.
+    'secure' => array(
+        'file' => 'secure.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre'
+    )
+];

--- a/lang/en/theme_saylor.php
+++ b/lang/en/theme_saylor.php
@@ -32,7 +32,7 @@ $string['advancedsettings'] = 'Advanced settings';
 $string['choosereadme'] = 'Theme Saylor is a child theme of Boost.';                
 $string['configtitle'] = 'Saylor theme settings';
 $string['generalsettings'] = 'General settings';
-
+$string['loginorsignupmessage'] = '<a href="{$a}"> Log in or Sign up</a> to track your course progress, gain access to final exams, and get a free certificate of completion!';
 $string['presetfiles'] = 'Additional theme preset files';
 $string['presetfiles_desc'] = 'Preset files can be used to dramatically alter the appearance of the theme. See <a href=https://docs.moodle.org/dev/Boost_Presets>Boost presets</a> for information on creating and sharing your own preset files, and see the <a href=http://moodle.net/boost>Presets repository</a> for presets that others have shared.';
 $string['preset'] = 'Theme preset';

--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -38,6 +38,7 @@ $bodyattributes = $OUTPUT->body_attributes($extraclasses);
 $blockshtml = $OUTPUT->blocks('side-pre');
 $hasblocks = strpos($blockshtml, 'data-block=') !== false;
 $regionmainsettingsmenu = $OUTPUT->region_main_settings_menu();
+$saylor_custom_enroll_button = $OUTPUT->saylor_custom_enroll_button();
 $templatecontext = [
     'sitename' => format_string($SITE->shortname, true, ['context' => context_course::instance(SITEID), "escape" => false]),
     'output' => $OUTPUT,
@@ -46,7 +47,8 @@ $templatecontext = [
     'bodyattributes' => $bodyattributes,
     'navdraweropen' => $navdraweropen,
     'regionmainsettingsmenu' => $regionmainsettingsmenu,
-    'hasregionmainsettingsmenu' => !empty($regionmainsettingsmenu)
+    'hasregionmainsettingsmenu' => !empty($regionmainsettingsmenu),
+    'saylorcustomenrollbutton' => $saylor_custom_enroll_button,
 ];
 
 $templatecontext['flatnavigation'] = $PAGE->flatnav;

--- a/renderers.php
+++ b/renderers.php
@@ -229,6 +229,32 @@ class theme_saylor_core_renderer extends theme_boost\output\core_renderer
             $usermenuclasses
         );
     }
+
+    /*
+    * This code shows an enroll button in main course view to logged in user or Login/sign up link when user is not logged in.
+    */
+    public function saylor_custom_enroll_button() {
+        global $COURSE, $PAGE;
+        // show nothing if user is already on enroll page.
+        if ($PAGE->pagetype == 'enrol-index') {
+                return "";
+        }
+        $output = html_writer::start_tag('div', array('id' => 'enroll-button-container', 'class' => 'enroll-container'));
+        $output .= html_writer::start_tag('div', array('id' => 'main-enroll-button', 'class' => 'center-block'));
+        $coursecontext = context_course::instance($COURSE->id);
+        if (isguestuser() || !isloggedin()) {
+            $link = new moodle_url('/login/index.php');
+            $output .= get_string('loginorsignupmessage', 'theme_saylor', $link->out());
+        } elseif (isloggedin($coursecontext) && !is_enrolled($coursecontext)) {
+            $link = new moodle_url('/enrol/index.php', array('id' => $COURSE->id));
+            $output .= $this->single_button($link->out(), get_string('enrolme', 'core_enrol'));
+        };
+        // Adding div that closes the main-enroll-button or the login/signup message.
+        $output .= html_writer::end_tag('div');
+        // Adding div that closes the enroll-button-container.
+        $output .= html_writer::end_tag('div');
+        return $output;
+    }
 }
 
 class theme_saylor_core_course_renderer extends \core_course_renderer

--- a/renderers.php
+++ b/renderers.php
@@ -235,7 +235,11 @@ class theme_saylor_core_renderer extends theme_boost\output\core_renderer
     */
     public function saylor_custom_enroll_button() {
         global $COURSE, $PAGE;
-        // show nothing if user is already on enroll page.
+        // Show nothing if the page layout is not course or incourse.
+        if (!($PAGE->pagelayout == 'course' || $PAGE->pagelayout == 'incourse')) {
+            return "";
+        }
+        // Show nothing if user is already on enroll page.
         if ($PAGE->pagetype == 'enrol-index') {
                 return "";
         }

--- a/scss/post.scss
+++ b/scss/post.scss
@@ -47,3 +47,10 @@ img.userpicture {
 	line-height: 0.25rem;
 	text-align: center;
 }
+
+// Enroll button
+#enroll-button-container {
+    font-size: 1.1em;
+    text-align: center;
+    padding-bottom: 5px;
+}

--- a/templates/columns2.mustache
+++ b/templates/columns2.mustache
@@ -74,6 +74,7 @@
                                 <div class="region_main_settings_menu_proxy"></div>
                             {{/hasregionmainsettingsmenu}}
                             {{{ output.course_content_header }}}
+                            {{{ saylorcustomenrollbutton }}}
                             {{{ output.main_content }}}
                             {{{ output.activity_navigation }}}
                             {{{ output.course_content_footer }}}


### PR DESCRIPTION
This ports the login message and enroll button to 2018. Only shown in courses and the course menu.

<img width="1125" alt="screen shot 2018-09-11 at 2 42 43 pm" src="https://user-images.githubusercontent.com/6720891/45361142-ba1c2880-b5d1-11e8-97af-ffdc7197ccd7.png">
<img width="1123" alt="screen shot 2018-09-11 at 2 38 14 pm" src="https://user-images.githubusercontent.com/6720891/45361143-ba1c2880-b5d1-11e8-9155-d5cf67eee4ae.png">
