### PR TITLE
Redefine boostrap buttons - btn-primary and btn-secondary

### DIFF
--- a/scss/preset/default.scss
+++ b/scss/preset/default.scss
@@ -253,12 +253,18 @@ body {
 
 // Button color should be our button orange.
 .btn-primary {
-    background-color: $button-bg-orange;
-    border-color: $button-bg-orange;
+    @include button-variant($button-bg-orange, darken($button-bg-orange, 7.5%), darken($button-bg-orange, 10%), lighten($button-bg-orange,5%), lighten($button-bg-orange, 10%), darken($button-bg-orange,30%));
+}
+
+.btn-outline-primary {
+    @include button-outline-variant($button-bg-orange, #222222, lighten($button-bg-orange,5%), $button-bg-orange);
 }
 .btn-secondary {
-    background-color: $button-bg-orange;
-    border-color: $button-bg-orange;
+    @include button-variant($button-bg-orange, darken($button-bg-orange, 7.5%), darken($button-bg-orange, 10%), lighten($button-bg-orange,5%), lighten($button-bg-orange, 10%), darken($button-bg-orange,30%));
+}
+
+.btn-outline-secondary {
+    @include button-outline-variant($button-bg-orange, #222222, lighten($button-bg-orange,5%), $button-bg-orange);
 }
 
 #page-wrapper {


### PR DESCRIPTION
Updated both the primary and secondary button definitions to get consistent behavior.