### PR TITLE
Add right border to nav-drawer

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -6,6 +6,10 @@ img.userpicture {
     margin-right: -.5rem;
 }
 
+#nav-drawer {
+	border-right: $card-border-width solid $card-border-color;
+}
+
 .navbar {
     box-shadow: 0 3px 0 $primary;
 }


### PR DESCRIPTION
This should make it a little easier to distinguish between the nav-drawer and the main content.

<img width="890" alt="screen shot 2018-09-13 at 1 02 54 pm" src="https://user-images.githubusercontent.com/6720891/45484720-620e2f00-b755-11e8-817e-c4058c163ee9.png">
