### PR TITLE
Remove box-shadowing on nav-drawer button

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -22,9 +22,17 @@ img.userpicture {
 	box-shadow: 0 0;
 	margin-bottom: 1rem;
 }
+
 .navbar .btn {
 	background-color: $gray-200;
 	border-color: $gray-200;
+	box-shadow: none;
+	-webkit-box-shadow: none;
+}
+
+.navbar .btn-secondary:not(.disabled):active:focus{
+	box-shadow: none;
+	-webkit-box-shadow: none;
 }
 
 .navbar .nav-link .fa-bars {


### PR DESCRIPTION
This PR removes some funky box shadowing that was appearing on the nav-drawer button in active and focused states. It was especially prominent when viewing the site on a mobile touch-screen device.