### PR TITLE
Feat/2018 remove participants

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -10,10 +10,12 @@ img.userpicture {
     margin-right: -.5rem;
 }
 
+/** Nav Drawer */
 #nav-drawer {
 	border-right: $card-border-width solid $card-border-color;
 }
 
+/** Nav Bar */
 .navbar {
     box-shadow: 0 3px 0 $primary;
 }

--- a/scss/post.scss
+++ b/scss/post.scss
@@ -14,6 +14,10 @@ img.userpicture {
 #nav-drawer {
 	border-right: $card-border-width solid $card-border-color;
 }
+// Hide the Participants node
+#nav-drawer a[data-key="participants"] {
+	display: none;
+}
 
 /** Nav Bar */
 .navbar {


### PR DESCRIPTION
This hides the 'Participants' node from the nav drawer - since we don't use that.