### PR TITLE
Hide Grades node in nav-drawer

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -18,6 +18,10 @@ img.userpicture {
 #nav-drawer a[data-key="participants"] {
 	display: none;
 }
+// Hide the Grades node
+#nav-drawer a[data-key="grades"] {
+	display: none;
+}
 
 /** Nav Bar */
 .navbar {


### PR DESCRIPTION
This hides the 'Grades' node in the nav-drawer. Students can view their grades from the profile dropdown in the top right.