### PR TITLE
Hide forum related links in user profile

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -189,3 +189,9 @@ img.userpicture {
 	border-radius: 2px;
 	color: #424242;
 }
+
+/** Profile Page */
+
+.userprofile .profile_tree a[href*="/mod/forum"] {
+	display: none;
+}


### PR DESCRIPTION
This hides the (moodle) forums related links in the user profile.