### PR TITLE
Hide resource navigation at the bottom of pages

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -218,3 +218,12 @@
 	border-radius: .25rem;
 	margin: .25rem 0 0 .25rem;
 }
+
+/** Resources */
+// Hide the resource navigation at the bottom of the resources.
+// It's confusing students.
+// Eventually, override the renderer to go to next unit.
+
+#region-main>.card>.card-body>.m-t-2 {
+	display: none;
+}


### PR DESCRIPTION
Navigation links at the bottom of resources might be confusing for students and cause them to miss important parts of the course. This PR hides (via CSS) that navigation.

Maybe in the future we can update renderers to go to the next unit/section?