### PR TITLE
Add html email header

### DIFF
--- a/templates/core/email_html.mustache
+++ b/templates/core/email_html.mustache
@@ -1,0 +1,82 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/email_html
+
+    Template for all html emails. Note that it may wrap content formatted
+    elsewhere in another a module template.
+
+    Context variables required for this template:
+    * sitefullname
+    * siteshortname
+    * sitewwwroot
+    * subject
+    * to
+    * toname
+    * touserid
+    * tousername
+    * from
+    * fromname
+    * replyto
+    * replytoname
+    * body
+
+    Example context (json):
+    {
+        "body": "Email body"
+    }
+}}
+<table class="module" role="module" data-type="code" border="0" cellpadding="0" cellspacing="0" width="100%" style="table-layout: fixed;">
+  <tr>
+    <td height="100%" valign="top">
+      <div style="height: 50px;width: 100%;"><a href="https://www.saylor.org"><img class="max-width" border="0" style="display:block;color:#000000;text-decoration:none;font-family:Helvetica, arial, sans-serif;font-size:16px;margin:auto;" data-proportionally-constrained="true" width="206" height="52" src="https://s3.amazonaws.com/saylordotorg-resources/logos/logo_dark_large.png" alt="Saylor Academy"></a></div>
+    </td>
+  </tr>
+</table>
+<table class="module"
+       role="module"
+       data-type="divider"
+       border="0"
+       cellpadding="0"
+       cellspacing="0"
+       width="100%"
+       style="table-layout: fixed;">
+  <tr>
+    <td style="padding:0px 0px 0px 0px;"
+        role="module-content"
+        height="100%"
+        valign="top"
+        bgcolor="">
+      <table border="0"
+             cellpadding="0"
+             cellspacing="0"
+             align="center"
+             width="100%"
+             height="3px"
+             style="line-height:3px; font-size:3px;">
+        <tr>
+          <td
+            style="padding: 0px 0px 3px 0px;"
+            bgcolor="#469dcd"></td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+<body style="margin-top:1rem;font-family:'Open Sans',sans-serif;">
+{{{body}}}
+</body>


### PR DESCRIPTION
Override the email_html template with a rough, inline-stylized version of our header.

Emails look like this:
<img width="855" alt="screen shot 2018-10-08 at 3 15 40 pm" src="https://user-images.githubusercontent.com/6720891/46628912-2163c480-cb0d-11e8-8025-30d0c9db01ee.png">
