### PR TITLE
Fix footer not floating to bottom of page

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -1,6 +1,12 @@
  // https://docs.moodle.org/dev/Creating_a_theme_based_on_boost#Why_do_we_use_pre_and_post_SCSS.3F
 // Post SCSS for the theme.
 
+#page-wrapper {
+	min-height: 100%;
+	height: auto;
+	padding-bottom: 1rem;
+}
+
 .content .sectionname {
 	margin-top: .5rem;
 }


### PR DESCRIPTION
This fixes the footer being pegged to the size of the initial viewport - and being hidden by content thats longer than the viewport.