### PR TITLE
Add canonical meta tag

### DIFF
--- a/renderers.php
+++ b/renderers.php
@@ -247,8 +247,12 @@ class theme_saylor_core_renderer extends theme_boost\output\core_renderer
         // Show different info in courses, such as the title and images.
         if ($PAGE->pagelayout == 'course' || $PAGE->pagelayout == 'incourse') {
             $title = str_replace("Course: ", "", $PAGE->title)." | ".$SITE->shortname;
+            // Filter out instances where the course name is listed twice 
+            // where a resource has the course name in it (like the final exams).
+            $title = str_replace($COURSE->shortname.": ".$COURSE->shortname.": ", $COURSE->shortname.": ", $title);
             $image = $COURSE->shortname."-1200x1200.png";
             $description = preg_replace('~((\{.*\})|(<.+>.*</.+>))~s', '', $COURSE->summary);
+            $canonical = "/course/".$COURSE->shortname;
         }
 
         $properties = new stdClass();
@@ -257,6 +261,9 @@ class theme_saylor_core_renderer extends theme_boost\output\core_renderer
         $properties->url = $url;
         $properties->image = $imagedomain.$image;
         $properties->description = html_entity_decode($description);
+        if (isset($canonical)) {
+            $properties->canonical = $canonical;
+        }
 
         return $properties;
     }

--- a/templates/head.mustache
+++ b/templates/head.mustache
@@ -27,6 +27,9 @@
     {{^opengraph}}
     <title>{{{ output.page_title }}}
     {{/opengraph}}
+    {{#opengraph.canonical}}
+    <link rel="canonical" href="{{opengraph.canonical}}" />
+    {{/opengraph.canonical}}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Open Graph -->
     {{#opengraph}}


### PR DESCRIPTION
Add a canonical tag to course (and unit, subunit, resource, etc) pages so the course main page is canonical.