### PR TITLE
Set atto editor content min-height to 160px

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -253,3 +253,10 @@
 .activity-navigation {
 	display: none;
 }
+
+/** Atto Editor */
+// Make the min height of editor boxes 160px.
+// In some places it's 28px and too small.
+.editor_atto_content {
+    min-height: 160px !important;
+}


### PR DESCRIPTION
Fixes #158.
<img width="995" alt="image" src="https://user-images.githubusercontent.com/6720891/55917420-40770800-5bbd-11e9-89f2-efcda086acd7.png">
