### PR TITLE
Fix footer partners typo

### DIFF
--- a/templates/footer.mustache
+++ b/templates/footer.mustache
@@ -37,7 +37,7 @@
             <div id="footer-links" class="d-inline-flex flex-row flex-nowrap align-items-center justify-content-between justify-content-sm-end mx-auto mr-sm-1 my-2">
                 <ul class="footer-nav d-flex align-items-center justify-content-center list-inline mt-auto mb-auto" >
                     <li class="list-inline-item"><h4><a href="https://www.saylor.org/about">About</a></h4></li>
-                    <li class="list-inline-item"><h4><a href="https://www.saylor.org/partners">Partner</a></h4></li>
+                    <li class="list-inline-item"><h4><a href="https://www.saylor.org/partners">Partners</a></h4></li>
                     <li class="list-inline-item"><h4><a href="https://www.saylor.org/blog">Blog</a></h4></li>
                     <li class="list-inline-item"><h4><a href="https://www.saylor.org/contact">Contact</a></h4></li>
                 </ul>


### PR DESCRIPTION
Fix typo in footer nav bar from "Partner" to "Partners", since this link takes user to our Partners page, not directly to a page prompting partnership

<img width="1240" alt="Footer partners typo" src="https://user-images.githubusercontent.com/9262502/58569971-204ee700-8205-11e9-80b5-4fb3cf35d21f.png">

@jazinheira 
