### PR TITLE
Blue standoutbox

### DIFF
--- a/mobileapp.css
+++ b/mobileapp.css
@@ -3,3 +3,7 @@
 /* 3.5 styles */
 
 @import url("https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css");
+
+.standoutbox.blue {
+	background-color: #e3f5fa;
+}

--- a/scss/post.scss
+++ b/scss/post.scss
@@ -356,3 +356,10 @@
 .editor_atto_content {
     min-height: 160px !important;
 }
+
+/** Standoutbox */
+// For a gray standoutbox, use the bootstrap class bg-light.
+// Blue standoutbox
+.standoutbox.blue {
+	background-color: $expand-light-blue-50;
+}


### PR DESCRIPTION
This will add the expand-light-blue-50 blue to the background of a standoutbox if it also has the class 'blue'. Additionally works on the mobile app.

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/6720891/67872977-207f4580-fb09-11e9-85de-c8442f13823b.png">
