### PR TITLE
Hide dashboard link in nav drawer

### DIFF
--- a/scss/saylor/_navigation.scss
+++ b/scss/saylor/_navigation.scss
@@ -98,6 +98,19 @@
   border-bottom-right-radius: .25rem;
 }
 
+// Hide the dashboard link.
+.list-group-item.list-group-item-action[data-key="myhome"] {
+    display: none;
+}
+
+// Since hiding the dashboard link removes the upper rounded corners, have to set the next element to have rounded corners.
+// That next element is currently the link to Saylor.org, with data key 'localboostnavigationcustomrootadmins1'.
+
+.list-group-item.list-group-item-action[data-key="localboostnavigationcustomrootadmins1"] {
+  border-top-left-radius: .25rem;
+  border-top-right-radius: .25rem;
+}
+
 /** Resources */
 // Hide the resource navigation at the bottom of the resources.
 // It's confusing students.


### PR DESCRIPTION
This hides the Dashboard link and fixes border rounding. Remember to unhide the dashboard node in boostnavigation settings!

<img width="289" alt="image" src="https://user-images.githubusercontent.com/6720891/116614162-91263e80-a907-11eb-9923-3e3633ea5146.png">
