### PR TITLE
Feat/update book navigation

### DIFF
--- a/scss/saylor/_button.scss
+++ b/scss/saylor/_button.scss
@@ -64,3 +64,22 @@
    text-align: center;
    padding-bottom: 5px;
 }
+
+/** Book Navigation */
+// Change the book navigation arrows to have buttons and text.
+// This is definitely a hack since we can't override any functions, renderers,
+// or mustache templates in /mod/book/view.php.
+
+.booknext {
+  @extend .btn, .btn-secondary, .btn-sm;
+}
+.booknext::before {
+  content: "Next Page ";
+}
+
+.bookprev {
+  @extend .btn, .btn-secondary, .btn-sm;
+}
+.bookprev::after {
+  content: "Previous Page ";
+}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021070800;
+$plugin->version   = 2021070801;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->requires  = 2020110300;
 $plugin->component = 'theme_saylor';


### PR DESCRIPTION
This PR adds secondary button styling and button text to the Images navstyle in Moodle books. Helps with issue #267 

<img width="828" alt="image" src="https://user-images.githubusercontent.com/6720891/124993384-4e24cd80-e012-11eb-806f-364f10cd5887.png">
