### PR TITLE
Feat/dashboard upgrade 2021

### DIFF
--- a/scss/saylor/_general.scss
+++ b/scss/saylor/_general.scss
@@ -23,11 +23,6 @@ a:visited {
   color: $link-color-visited;
 }
 
-// Rounded user pictures
-.userpicture {
-    border-radius: 50%;
-}
-
 h1,
 .h1,
 h2,
@@ -63,7 +58,7 @@ h6,
 
 // Rounded user pictures
 .userpicture {
-    border-radius: 50%;
+    border-radius: 50% !important;
 }
 
 // Increase font size for user log in/sign up top-right header.

--- a/scss/saylor/_general.scss
+++ b/scss/saylor/_general.scss
@@ -182,3 +182,18 @@ h6,
     padding: 0.5rem 0.25rem 0 0.75rem;
   };
 }
+
+/** Progress Bars */
+.progress-bar {
+    @extend .bg-tertiary, .border, .border-primary, .rounded-left;
+}
+
+.progress-bar[aria-valuenow="0"] {
+    border: 0px !important;
+}
+
+.progress-bar[aria-valuenow="100"] {
+    @extend .rounded-right;
+}
+
+

--- a/scss/saylor/_overview.scss
+++ b/scss/saylor/_overview.scss
@@ -1,3 +1,16 @@
+.dashboard-card {
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: .25rem !important;
+    margin-bottom: .25rem !important;
+    max-width: 350px;
+    min-width: 250px;
+}
+
+.card-deck {
+    justify-content: center;
+}
+
 $chart-size: 70px;
 $doughnut-border-size: 15px;
 $doughnut-dasharray: 173;
@@ -136,3 +149,5 @@ $doughnut-fill-colour: $brand-warning;
         }
     }
 }
+
+

--- a/scss/saylor/_variables.scss
+++ b/scss/saylor/_variables.scss
@@ -172,6 +172,7 @@ $expand-green-900:     #009400 !default;
 // Theme variables
 $primary:       $primary-light-blue;
 $secondary:     $primary-orange !default;
+$tertiary:      $primary-dark-blue !default;
 $success:       $expand-green-900 !default;
 $info:          $expand-teal-700 !default;
 $warning:       $expand-yellow-700 !default;
@@ -236,6 +237,7 @@ $theme-colors: () !default;
 $theme-colors: map-merge((
     primary: $primary,
     secondary: $secondary,
+    tertiary: $tertiary,
     success: $success,
     info: $info,
     warning: $warning,

--- a/templates/block_myoverview/course-action-menu.mustache
+++ b/templates/block_myoverview/course-action-menu.mustache
@@ -1,0 +1,80 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_myoverview/course-action-menu
+
+    This template renders action menu for each course.
+
+    Example context (json):
+    {
+        "isfavourite": true
+    }
+}}
+<div class="ml-auto dropdown">
+    <button class="border border-rounded btn btn-link btn-icon icon-size-3 coursemenubtn"
+        type="button"
+        data-toggle="dropdown"
+        aria-haspopup="true"
+        aria-expanded="false">
+        {{#pix}} i/moremenu, core {{/pix}}
+            <span class="sr-only">
+                {{#str}} aria:courseactions, block_myoverview {{/str}} {{{fullname}}}
+            </span>
+    </button>
+    <div class="dropdown-menu dropdown-menu-right">
+        <a class="dropdown-item {{#isfavourite}}hidden{{/isfavourite}}" href="#"
+            data-action="add-favourite"
+            data-course-id="{{id}}"
+            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
+            >
+            {{#str}} addtofavourites, block_myoverview {{/str}}
+            <div class="sr-only">
+                {{#str}} aria:addtofavourites, block_myoverview {{/str}} {{{fullname}}}
+            </div>
+        </a>
+        <a class="dropdown-item {{^isfavourite}}hidden{{/isfavourite}}" href="#"
+            data-action="remove-favourite"
+            data-course-id="{{id}}"
+            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
+            >
+            {{#str}} removefromfavourites, block_myoverview {{/str}}
+            <div class="sr-only">
+                {{#str}} aria:removefromfavourites, block_myoverview {{/str}} {{{fullname}}}
+            </div>
+        </a>
+        <a class="dropdown-item {{^hidden}}hidden{{/hidden}}" href="#"
+            data-action="show-course"
+            data-course-id="{{id}}"
+            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
+            >
+            {{#str}} show, block_myoverview {{/str}}
+            <div class="sr-only">
+                {{#str}} aria:showcourse, block_myoverview, {{fullname}} {{/str}}
+            </div>
+        </a>
+        <a class="dropdown-item {{#hidden}}hidden{{/hidden}}" href="#"
+            data-action="hide-course"
+            data-course-id="{{id}}"
+            aria-controls="favorite-icon-{{ id }}-{{ uniqid }}"
+            >
+            {{#str}} hidecourse, block_myoverview {{/str}}
+            <div class="sr-only">
+                {{#str}} aria:hidecourse, block_myoverview, {{fullname}} {{/str}}
+            </div>
+        </a>
+    </div>
+</div>

--- a/templates/block_myoverview/nav-display-selector.mustache
+++ b/templates/block_myoverview/nav-display-selector.mustache
@@ -27,30 +27,22 @@
     }
 }}
 <div class="dropdown mb-1">
-    <button id="displaydropdown" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+    <button id="displaydropdown" type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
     aria-label="{{#str}} aria:displaydropdown, block_myoverview {{/str}}">
         {{#pix}} a/view_icon_active {{/pix}}
         <span class="d-sm-inline-block" data-active-item-text>
-            {{#cards}}{{#str}} card, block_myoverview {{/str}}{{/cards}}
+            {{#card}}{{#str}} card, block_myoverview {{/str}}{{/card}}
             {{#list}}{{#str}} list, block_myoverview {{/str}}{{/list}}
             {{#summary}}{{#str}} summary, block_myoverview {{/str}}{{/summary}}
         </span>
     </button>
-    <ul class="dropdown-menu" data-show-active-item aria-labelledby="displaydropdown">
-        <li>
-            <a class="dropdown-item {{#cards}}active{{/cards}}" href="#" data-display-option="display" data-value="cards" data-pref="cards" aria-label="{{#str}} aria:card, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}">
-            {{#str}} card, block_myoverview {{/str}}
-            </a>
-        </li>
-        <li>
-            <a class="dropdown-item {{#list}}active{{/list}}" href="#" data-display-option="display" data-value="list" data-pref="list" aria-label="{{#str}} aria:list, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}">
-            {{#str}} list, block_myoverview {{/str}}
-            </a>
-        </li>
-        <li>
-            <a class="dropdown-item {{#summary}}active{{/summary}}" href="#" data-display-option="display" data-value="summary" data-pref="summary" aria-label="{{#str}} aria:summary, block_myoverview {{/str}}" aria-controls="courses-view-{{uniqid}}">
-            {{#str}} summary, block_myoverview {{/str}}
-            </a>
-        </li>
+    <ul class="dropdown-menu" role="menu" data-show-active-item data-skip-active-class="true" aria-labelledby="displaydropdown">
+    {{#layouts}}
+            <li>
+                <a class="dropdown-item" href="#" data-display-option="display" data-value="{{id}}" data-pref="{{id}}" aria-label="{{arialabel}}" aria-controls="courses-view-{{uniqid}}" role="menuitem" {{#active}}aria-current="true"{{/active}}>
+                    {{name}}
+                </a>
+            </li>
+    {{/layouts}}
     </ul>
 </div>

--- a/templates/block_myoverview/nav-grouping-selector.mustache
+++ b/templates/block_myoverview/nav-grouping-selector.mustache
@@ -28,7 +28,7 @@
     }
 }}
 <div class="dropdown mb-1 mr-auto">
-    <button id="groupingdropdown" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="{{#str}} aria:groupingdropdown, block_myoverview {{/str}}">
+    <button id="groupingdropdown" type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="{{#str}} aria:groupingdropdown, block_myoverview {{/str}}">
         {{#pix}} i/filter {{/pix}}
         <span class="d-sm-inline-block" data-active-item-text>
             {{#all}}{{#str}} all, block_myoverview {{/str}}{{/all}}

--- a/templates/block_myoverview/nav-sort-selector.mustache
+++ b/templates/block_myoverview/nav-sort-selector.mustache
@@ -28,7 +28,7 @@
 
 <div class="mb-1 mr-1 d-flex align-items-center">
     <div class="dropdown">
-        <button id="sortingdropdown" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown"  aria-haspopup="true" aria-expanded="false" aria-label="{{#str}} aria:sortingdropdown, block_myoverview {{/str}}">
+        <button id="sortingdropdown" type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown"  aria-haspopup="true" aria-expanded="false" aria-label="{{#str}} aria:sortingdropdown, block_myoverview {{/str}}">
             {{#pix}} t/sort_by {{/pix}}
             <span class="d-sm-inline-block" data-active-item-text>
                 {{#title}}{{#str}} title, block_myoverview {{/str}}{{/title}}

--- a/templates/block_myoverview/progress-bar.mustache
+++ b/templates/block_myoverview/progress-bar.mustache
@@ -1,0 +1,34 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_myoverview/progress-bar
+
+    This template renders a simple progress bar.
+
+    Example context (json):
+    {
+        "progress": 50
+    }
+}}
+
+<div class="progress">
+    <div class="progress-bar bar" role="progressbar" aria-valuenow="{{progress}}" style="width: {{progress}}%" aria-valuemin="0" aria-valuemax="100"></div>
+</div>
+<div class="small">
+    <span class="sr-only">{{#str}}aria:courseprogress, block_myoverview{{/str}}</span>
+    {{#str}}completepercent, block_myoverview, <strong>{{progress}}</strong>{{/str}}
+</div>

--- a/templates/block_myoverview/view-cards.mustache
+++ b/templates/block_myoverview/view-cards.mustache
@@ -38,7 +38,7 @@
 
 {{< core_course/coursecards }}
     {{$menu}}
-        <div class="pl-2">
+        <div class="px-2">
             {{> block_myoverview/course-action-menu }}
         </div>
     {{/menu}}

--- a/templates/block_myoverview/view-cards.mustache
+++ b/templates/block_myoverview/view-cards.mustache
@@ -1,0 +1,72 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template block_myoverview/view-cards
+
+    This template renders the cards view for the myoverview block.
+
+    Example context (json):
+    {
+        "courses": [
+            {
+                "name": "Assignment due 1",
+                "viewurl": "https://moodlesite/course/view.php?id=2",
+                "courseimage": "https://moodlesite/pluginfile/123/course/overviewfiles/123.jpg",
+                "fullname": "course 3",
+                "hasprogress": true,
+                "progress": 10,
+                "coursecategory": "Miscellaneous",
+                "visible": true
+            }
+        ]
+    }
+}}
+
+{{< core_course/coursecards }}
+    {{$menu}}
+        <div class="pl-2">
+            {{> block_myoverview/course-action-menu }}
+        </div>
+    {{/menu}}
+    {{$progress}}
+        {{#hasprogress}}
+            <div class="card-footer dashboard-card-footer border-0 bg-white">
+                {{> block_myoverview/progress-bar}}
+            </div>
+        {{/hasprogress}}
+    {{/progress}}
+    {{$coursename}}
+        <span class="multiline">
+            {{#shortentext}}50, {{{fullname}}} {{/shortentext}}
+        </span>
+    {{/coursename}}
+    {{$coursecategory}}
+        {{#showcoursecategory}}
+            <span class="sr-only">
+                {{#str}}aria:coursecategory, core_course{{/str}}
+            </span>
+            <span class="categoryname text-truncate">
+                {{{coursecategory}}}
+            </span>
+        {{/showcoursecategory}}
+    {{/coursecategory}}
+    {{$divider}}
+        {{#showcoursecategory}}
+            <div class="pl-1 pr-1">|</div>
+        {{/showcoursecategory}}
+    {{/divider}}
+{{/ core_course/coursecards }}

--- a/templates/block_myoverview/view-list.mustache
+++ b/templates/block_myoverview/view-list.mustache
@@ -41,44 +41,58 @@
     <li class="list-group-item course-listitem"
         data-region="course-content"
         data-course-id="{{{id}}}">
-        <div class="row-fluid">
-            <div class="{{#hasprogress}}col-md-6{{/hasprogress}}{{^hasprogress}}col-md-11 col-md-11{{/hasprogress}} d-flex align-items-center">
-                <div>
-                    <div class="text-muted muted d-flex flex-wrap">
-                        <span class="sr-only">
-                            {{#str}}aria:coursecategory, core_course{{/str}}
-                        </span>
-                        <span class="categoryname">
-                            {{{coursecategory}}}
-                        </span>
-                        {{#showshortname}}
-                        <div class="pl-1 pr-1">|</div>
-                        <span class="sr-only">
-                            {{#str}}aria:courseshortname, core_course{{/str}}
-                        </span>
-                        <div>{{{shortname}}}</div>
-                        {{/showshortname}}
+        <div class="d-flex flex-column flex-sm-row">
+            <div class="p-3 flex-grow-1 flex-sm-grow-0 flex-sm-shrink-1">
+                {{! Course thumbnail image }}
+                <a href="{{viewurl}}" tabindex="-1">
+                    <div class="summaryimage rounded-circle mx-auto" style='background-image: url("{{{courseimage}}}");'>
+                        <span class="sr-only">{{#str}}aria:courseimage, core_course{{/str}}</span>
                     </div>
-                    <a href="{{viewurl}}" class="coursename">
-                        <span class="sr-only">
-                            {{#str}}aria:coursename, core_course{{/str}}
-                        </span>
-                        <h3 class="course-title">{{> core_course/favouriteicon }}{{{fullname}}}</h3>
-                    </a>
-                    {{^visible}}
-                        <div class="d-flex flex-wrap">
-                            <span class="tag tag-info">{{#str}} hiddenfromstudents {{/str}}</span>
+                </a>
+            </div>
+            <div class="row-fluid flex-grow-1">
+                <div class="d-flex align-items-center">
+                    <div class="w-100">
+                        <div class="d-flex flex-row justify-content-between">
+                            <div class="text-muted muted d-flex pt-3">
+                                <span class="sr-only">
+                                    {{#str}}aria:coursecategory, core_course{{/str}}
+                                </span>
+                                <span class="categoryname">
+                                    {{{coursecategory}}}
+                                </span>
+                                {{#showshortname}}
+                                <div class="pl-1 pr-1">|</div>
+                                <span class="sr-only">
+                                    {{#str}}aria:courseshortname, core_course{{/str}}
+                                </span>
+                                <div>{{{shortname}}}</div>
+                                {{/showshortname}}
+                            </div>
+                            <div class="pl-2">
+                                {{> block_myoverview/course-action-menu }}
+                            </div>
                         </div>
-                    {{/visible}}
+                        <div class="d-flex flex-nowrap">
+                            <a href="{{viewurl}}" class="coursename">
+                                <span class="sr-only">
+                                    {{#str}}aria:coursename, core_course{{/str}}
+                                </span>
+                                <h3 class="course-title">{{> core_course/favouriteicon }}{{{fullname}}}</h3>
+                            </a>
+                            {{^visible}}
+                                <div class="d-flex flex-wrap">
+                                    <span class="tag tag-info">{{#str}} hiddenfromstudents {{/str}}</span>
+                                </div>
+                            {{/visible}}
+                        </div>
+                    </div>
                 </div>
-            </div>
-            {{#hasprogress}}
-            <div class="col-md-5 pt-1">
-                {{> block_myoverview/progress-bar}}
-            </div>
-            {{/hasprogress}}
-            <div class="col-md-1 p-0 d-flex">
-                {{> block_myoverview/course-action-menu }}
+                {{#hasprogress}}
+                <div class="row-fluid pt-1">
+                    {{> block_myoverview/progress-bar}}
+                </div>
+                {{/hasprogress}}
             </div>
         </div>
     </li>

--- a/templates/block_myoverview/view-list.mustache
+++ b/templates/block_myoverview/view-list.mustache
@@ -42,7 +42,7 @@
         data-region="course-content"
         data-course-id="{{{id}}}">
         <div class="d-flex flex-column flex-sm-row">
-            <div class="p-3 flex-grow-1 flex-sm-grow-0 flex-sm-shrink-1">
+            <div class="pl-sm-0 pr-sm-3 py-sm-3 px-3 py-0 flex-grow-1 flex-sm-grow-0 flex-sm-shrink-1">
                 {{! Course thumbnail image }}
                 <a href="{{viewurl}}" tabindex="-1">
                     <div class="summaryimage rounded-circle mx-auto" style='background-image: url("{{{courseimage}}}");'>

--- a/templates/block_myoverview/view-summary.mustache
+++ b/templates/block_myoverview/view-summary.mustache
@@ -41,26 +41,37 @@
     <div class="course-summaryitem mb-1 p-2" role="listitem"
         data-region="course-content"
         data-course-id="{{{id}}}">
-        <div class="d-flex">
-            {{! Course thumbnail image }}
-
+        <div class="d-flex flex-column flex-sm-row">
+            <div class="mx-auto p-3">
+                {{! Course thumbnail image }}
+                <a href="{{viewurl}}" tabindex="-1">
+                    <div class="summaryimage rounded-circle" style='background-image: url("{{{courseimage}}}");'>
+                        <span class="sr-only">{{#str}}aria:courseimage, core_course{{/str}}</span>
+                    </div>
+                </a>
+            </div>
             <div class="align-self-stretch d-flex flex-column w-100">
-                <div class="text-muted muted mb-1 d-flex flex-wrap">
-                    <span class="sr-only">
-                        {{#str}}aria:coursecategory, core_course{{/str}}
-                    </span>
-                    {{$coursecategory}}
-                    <span class="categoryname">
-                        {{{coursecategory}}}
-                    </span>
-                    {{/coursecategory}}
-                    {{#showshortname}}
-                    <div class="pl-1 pr-1">|</div>
-                    <span class="sr-only">
-                        {{#str}}aria:courseshortname, core_course{{/str}}
-                    </span>
-                    <div>{{{shortname}}}</div>
-                    {{/showshortname}}
+                <div class="d-flex flex-row justify-content-between">
+                    <div class="text-muted muted pt-3 d-flex flex-wrap">
+                        <span class="sr-only">
+                            {{#str}}aria:coursecategory, core_course{{/str}}
+                        </span>
+                        {{$coursecategory}}
+                        <span class="categoryname">
+                            {{{coursecategory}}}
+                        </span>
+                        {{/coursecategory}}
+                        {{#showshortname}}
+                        <div class="pl-1 pr-1">|</div>
+                        <span class="sr-only">
+                            {{#str}}aria:courseshortname, core_course{{/str}}
+                        </span>
+                        <div>{{{shortname}}}</div>
+                        {{/showshortname}}
+                    </div>
+                    <div class="pl-2">
+                        {{> block_myoverview/course-action-menu }}
+                    </div>
                 </div>
                 <div class="d-flex mb-1">
                     <a href="{{viewurl}}" class="coursename">
@@ -69,7 +80,6 @@
                         </span>
                         <h3 class="course-title">{{> core_course/favouriteicon }}{{{fullname}}}</h3>
                     </a>
-                    {{> block_myoverview/course-action-menu }}
                 </div>
                 {{^visible}}
                     <div class="d-flex flex-wrap">
@@ -80,7 +90,7 @@
                     <span class="sr-only">{{#str}}aria:coursesummary, block_myoverview{{/str}}</span>
                     {{{summary}}}
                 </div>
-                <div class="ml-auto mt-auto w-50 p-t-1">
+                <div class="ml-auto mt-auto w-100 p-t-1">
                     {{#hasprogress}}
                         {{> block_myoverview/progress-bar}}
                     {{/hasprogress}}

--- a/templates/block_myoverview/view-summary.mustache
+++ b/templates/block_myoverview/view-summary.mustache
@@ -42,7 +42,7 @@
         data-region="course-content"
         data-course-id="{{{id}}}">
         <div class="d-flex flex-column flex-sm-row">
-            <div class="mx-auto p-3">
+            <div class="mx-auto p-3 pl-sm-0 pr-sm-2">
                 {{! Course thumbnail image }}
                 <a href="{{viewurl}}" tabindex="-1">
                     <div class="summaryimage rounded-circle" style='background-image: url("{{{courseimage}}}");'>

--- a/templates/block_myoverview/view-summary.mustache
+++ b/templates/block_myoverview/view-summary.mustache
@@ -86,11 +86,11 @@
                          <span class="tag tag-info">{{#str}} hiddenfromstudents {{/str}}</span>
                      </div>
                 {{/visible}}
-                <div class="summary">
+                <div class="summary pr-sm-6">
                     <span class="sr-only">{{#str}}aria:coursesummary, block_myoverview{{/str}}</span>
                     {{{summary}}}
                 </div>
-                <div class="ml-auto mt-auto w-100 p-t-1">
+                <div class="ml-auto mt-auto w-100 p-t-1 pr-sm-6">
                     {{#hasprogress}}
                         {{> block_myoverview/progress-bar}}
                     {{/hasprogress}}

--- a/templates/core/paged_content_paging_bar.mustache
+++ b/templates/core/paged_content_paging_bar.mustache
@@ -55,7 +55,7 @@
             <div class="btn-group">
                 <button
                     type="button"
-                    class="btn btn-primary dropdown-toggle"
+                    class="btn btn-secondary btn-sm dropdown-toggle"
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false"

--- a/templates/core/paged_content_paging_bar_item.mustache
+++ b/templates/core/paged_content_paging_bar_item.mustache
@@ -1,0 +1,41 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template core/paged_content_paging_bar_item
+
+    This template renders a single item in the paging bar.
+
+    Example context (json):
+    {
+        "url": "#",
+        "number": 1,
+        "page": "1",
+        "active": true
+    }
+}}
+<li class="page-item {{#active}}active{{/active}} {{#disabled}}disabled{{/disabled}}"
+    data-region="page-item"
+    {{$attributes}}{{/attributes}}>
+
+    <a href="{{#url}}{{.}}{{/url}}{{^url}}#{{/url}}"
+       class="page-link btn-secondary m-0"
+       data-region="page-link" {{$linkattributes}}aria-label="{{#str}}pagea, moodle, {{page}}{{/str}}"{{/linkattributes}}>
+        {{$item-content}}
+            {{{page}}}
+        {{/item-content}}
+    </a>
+</li>

--- a/templates/core_course/coursecard.mustache
+++ b/templates/core_course/coursecard.mustache
@@ -37,7 +37,14 @@
 <div class="card dashboard-card" role="listitem"
     data-region="course-content"
     data-course-id="{{{id}}}">
-{{! Course image/link goes here. }}
+    {{! Course image/link goes here. }}
+    <div>
+        <a href="{{viewurl}}" tabindex="-1">
+            <img class="card-img dashboard-card-img h-auto mw-100" height="1080" width="1920" style='background-image: url("{{{courseimage}}}");'>
+                <span class="sr-only">{{#str}}aria:courseimage, core_course{{/str}}</span>
+            </img>
+        </a>
+    </div>
     <div class="card-body pr-1 course-info-container" id="course-info-container-{{id}}-{{uniqid}}">
         <div class="d-flex align-items-start">
             <div class="w-100 text-truncate">

--- a/templates/core_course/coursecard.mustache
+++ b/templates/core_course/coursecard.mustache
@@ -48,7 +48,7 @@
     <div class="card-body pr-1 course-info-container" id="course-info-container-{{id}}-{{uniqid}}">
         <div class="d-flex align-items-start">
             <div class="w-100 text-truncate">
-                <div class="text-muted muted d-flex mb-1 flex-wrap">
+                <div class="text-muted muted d-flex pt-2 flex-wrap">
                     {{$coursecategory}}{{/coursecategory}}
                     {{#showshortname}}
                     {{$divider}}{{/divider}}

--- a/templates/mydashboard.mustache
+++ b/templates/mydashboard.mustache
@@ -61,7 +61,10 @@
     {{> /nav-drawer }}
 
     <div id="page" class="container-fluid d-print-block">
+       
+        <div class="d-none">
         {{{ output.full_header }}}
+        </div>
 
         <div class="container-fluid container-alert">
                     {{#enable1alert}}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021070801;
+$plugin->version   = 2021070816;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->requires  = 2020110300;
 $plugin->component = 'theme_saylor';


### PR DESCRIPTION
Added many improvements to the dashboard while working on the lesson updates:
- Hid the header that didn't show any useful information.
- Fixed the card view so cards actually show (cards are 250px-350px).
- Added course images.
- Updated button styling to use secondary buttons and take advantage of the smaller button sizes.
- Added a tertiary color as an option for bootstrap classes.
- Styled progress bars site-wide.
- Styled pagination buttons.
- Added border to triple dot buttons to denote them as buttons.

<img width="520" alt="image" src="https://user-images.githubusercontent.com/6720891/125951286-6382c1b2-6cd8-4db3-ae3e-03b593e7605c.png">

<img width="521" alt="image" src="https://user-images.githubusercontent.com/6720891/125951364-7c77e870-d202-4727-8bc1-cae033c85d7c.png">

<img width="1169" alt="image" src="https://user-images.githubusercontent.com/6720891/125951455-cd3fefcd-755b-4540-8248-d0e6e007b83d.png">

<img width="448" alt="image" src="https://user-images.githubusercontent.com/6720891/125951512-badf632b-594c-4f0e-b28b-9ef8137e0354.png">

<img width="1055" alt="image" src="https://user-images.githubusercontent.com/6720891/125951574-e2a8ef10-223c-4efe-8411-dfd6f59a3278.png">

<img width="462" alt="image" src="https://user-images.githubusercontent.com/6720891/125951620-fe2e1fe5-4a50-4d71-afce-8e1ca195cd24.png">

<img width="1384" alt="image" src="https://user-images.githubusercontent.com/6720891/125951653-64efdc30-0cc5-48cd-9eca-1ce3ed0f0e57.png">

<img width="413" alt="image" src="https://user-images.githubusercontent.com/6720891/125951710-69b745b9-e9e3-420d-aed8-90c00ee019c7.png">

<img width="432" alt="image" src="https://user-images.githubusercontent.com/6720891/125951737-70173624-48c7-45b5-8c0b-7e298da4bc67.png">

