### PR TITLE
Change activity navigation buttons to use font awesome long arrows

### DIFF
--- a/templates/core_course/activity_navigation.mustache
+++ b/templates/core_course/activity_navigation.mustache
@@ -77,7 +77,7 @@
     </div>
     <div class="container-fluid d-flex flex-column flex-sm-row flex-wrap flex-sm-nowrap align-items-center justify-content-center justify-content-md-around">
         <div id="activitynavprev" class="py-1 px-1 text-nowrap">
-            {{#prevlink}}<a class="btn btn-primary" href="{{ prevlink.url }}" role="button">◄ {{#str}}activitynavprev, theme_saylor{{/str}}</a>{{/prevlink}}
+            {{#prevlink}}<a class="btn btn-primary" href="{{ prevlink.url }}" role="button"><i class="icon fa fa-long-arrow-left fa-fw m-0 pr-1" aria-hidden="true"></i>{{#str}}activitynavprev, theme_saylor{{/str}}</a>{{/prevlink}}
         </div>
 
         <div id="activitynavlist" class="py-1 px-1 text-nowrap">
@@ -85,7 +85,7 @@
         </div>
 
         <div id="activitynavnext" class="py-1 px-1 text-nowrap">
-            {{#nextlink}}<a  class="btn btn-primary" href="{{ nextlink.url }}" role="button">{{#str}}activitynavnext, theme_saylor{{/str}} ►</a>{{/nextlink}}
+            {{#nextlink}}<a  class="btn btn-primary" href="{{ nextlink.url }}" role="button">{{#str}}activitynavnext, theme_saylor{{/str}}<i class="icon fa fa-long-arrow-right fa-fw m-0 pl-1" aria-hidden="true"></i></a>{{/nextlink}}
         </div>
     </div>
 </div>


### PR DESCRIPTION
Since we were having issues with unicode arrows rendering differently on different machines, swapped to using the long arrow in font awesome to increase compatibility and preserve the icon being different from other navigation arrows.

<img width="483" alt="image" src="https://user-images.githubusercontent.com/6720891/125972707-17943bb6-d5f0-41aa-89ce-b634f615312d.png">
