### PR TITLE
Change casing on book nav buttons to match other buttons

### DIFF
--- a/scss/saylor/_button.scss
+++ b/scss/saylor/_button.scss
@@ -74,12 +74,12 @@
   @extend .btn, .btn-secondary, .btn-sm;
 }
 .booknext::before {
-  content: "Next Page ";
+  content: "Next page ";
 }
 
 .bookprev {
   @extend .btn, .btn-secondary, .btn-sm;
 }
 .bookprev::after {
-  content: "Previous Page ";
+  content: "Previous page ";
 }


### PR DESCRIPTION
Fix to match the book nav button casing with other buttons.

<img width="145" alt="image" src="https://user-images.githubusercontent.com/6720891/125973019-dbc9790b-c7ab-40b8-a9df-8445455a630b.png">
