### PR TITLE
Fix/quiz nav buttons

### DIFF
--- a/scss/saylor/_button.scss
+++ b/scss/saylor/_button.scss
@@ -100,3 +100,10 @@
 .bookexit {
     display: none;
 }
+
+/** Quizzes */
+
+// Style the quiz nav buttons.
+.mod_quiz-prev-nav, .mod_quiz-next-nav {
+  @extend .btn, .btn-secondary, .btn-sm;
+}

--- a/scss/saylor/_button.scss
+++ b/scss/saylor/_button.scss
@@ -107,3 +107,8 @@
 .mod_quiz-prev-nav, .mod_quiz-next-nav {
   @extend .btn, .btn-secondary, .btn-sm;
 }
+
+// Add bottom padding.
+#page-mod-quiz-attempt .submitbtns, #page-mod-quiz-summary .submitbtns, #page-mod-quiz-review .submitbtns {
+  padding-bottom: 2em;
+}

--- a/scss/saylor/_navigation.scss
+++ b/scss/saylor/_navigation.scss
@@ -111,14 +111,16 @@
   border-top-right-radius: .25rem;
 }
 
-/** Resources */
-// Hide the resource navigation at the bottom of the resources.
-// It's confusing students.
-// Eventually, override the renderer to go to next unit.
-
+/** Activity Navigation */
 .activity-navigation .row {
     align-items: normal;
 }
+
+// Hide activity navigation during quiz attempts.
+#page-mod-quiz-attempt .activity-navigation, #page-mod-quiz-summary .activity-navigation {
+  display: none;
+}
+
 /** Navigation Menu */
 
 .list-group-item.localboostnavigationfirstcustombuttomusers {

--- a/scss/saylor/_quiz.scss
+++ b/scss/saylor/_quiz.scss
@@ -2,7 +2,7 @@
 
 .path-mod-quiz #mod_quiz_navblock {
    .qnbutton {
-     color: $primary;
+     color: $tertiary;
  }
 }
 
@@ -46,6 +46,7 @@
   padding-top: .5rem;
 }
 
-.qnbutton .trafficlight {
-    margin-top: 30px !important;
+.path-mod-quiz #mod_quiz_navblock .qnbutton .trafficlight {
+  height: 10px;
+  margin-top: 30px;
 }


### PR DESCRIPTION
Updated quizzes:

1) Stylized the bottom quiz nav buttoms to btn-secondary and btn-sm. Added bottom padding.
2) Removed activity navigation buttons during quiz attempts
4) Cleaned up the quiz navigation block: made the cells a darker, easier to read color and fixed the traffic light positioning.

![image](https://user-images.githubusercontent.com/6720891/135507105-777be95e-8bef-49d4-9214-c51bbf72a836.png)

![image](https://user-images.githubusercontent.com/6720891/135507206-5345c665-c30f-4c92-94ed-a22ddb148d8e.png)

