### PR TITLE
Remove d-flex class from the region-main-box to expand course catalog

### DIFF
--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -60,8 +60,8 @@
     <div id="page" class="container-fluid">
 
         <div id="page-content" class="row">
-            <div id="region-main-box" class="col-12 d-flex flex-column flex-lg-row justify-content-center">
-                <section id="region-center">
+            <div id="region-main-box" class="col-12 flex-column flex-lg-row justify-content-center">
+                <section id="region-center" {{#hassideblocks}}class="has-blocks mb-3" {{/hassideblocks}}aria-label="Content">
                 {{#hastopblocks}}
                 <section id="region-top" data-region="blocks-row" class="d-print-none mt-3">
                     {{{ topblocks }}}

--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -60,7 +60,7 @@
     <div id="page" class="container-fluid">
 
         <div id="page-content" class="row">
-            <div id="region-main-box" class="col-12 flex-column flex-lg-row justify-content-center">
+            <div id="region-main-box" class="col-12 d-flex flex-column justify-content-center">
                 <section id="region-center" {{#hassideblocks}}class="has-blocks mb-3" {{/hassideblocks}}aria-label="Content">
                 {{#hastopblocks}}
                 <section id="region-top" data-region="blocks-row" class="d-print-none mt-3">

--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -61,7 +61,7 @@
 
         <div id="page-content" class="row">
             <div id="region-main-box" class="col-12 d-flex flex-column justify-content-center">
-                <section id="region-center" {{#hassideblocks}}class="has-blocks mb-3" {{/hassideblocks}}aria-label="Content">
+                <section id="region-center" aria-label="Content">
                 {{#hastopblocks}}
                 <section id="region-top" data-region="blocks-row" class="d-print-none mt-3">
                     {{{ topblocks }}}

--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -60,7 +60,7 @@
     <div id="page" class="container-fluid">
 
         <div id="page-content" class="row">
-            <div id="region-main-box" class="col-12 d-flex flex-column justify-content-center">
+            <div id="region-main-box" class="col-12 d-flex flex-column flex-row justify-content-center">
                 <section id="region-center" aria-label="Content">
                 {{#hastopblocks}}
                 <section id="region-top" data-region="blocks-row" class="d-print-none mt-3">
@@ -68,11 +68,11 @@
                 </section>
                 {{/hastopblocks}}
                 {{#hasregionmainsettingsmenu}}
-                <div id="region-main-settings-menu" class="d-print-none {{#hasblocks}}has-blocks{{/hasblocks}}">
+                <div id="region-main-settings-menu" class="d-print-none {{#hassideblocks}}has-blocks{{/hassideblocks}}">
                     <div> {{{ output.region_main_settings_menu }}} </div>
                 </div>
                 {{/hasregionmainsettingsmenu}}
-                <section id="region-main" class="{{#hasblocks}}has-blocks {{/hasblocks}}my-3 card">
+                <section id="region-main" class="{{#hassideblocks}}has-blocks {{/hassideblocks}}my-3 card">
                     {{#hasregionmainsettingsmenu}}
                         <div class="region_main_settings_menu_proxy"></div>
                     {{/hasregionmainsettingsmenu}}


### PR DESCRIPTION
Removed d-flex class from frontpage template to expand the course catalog

![image](https://user-images.githubusercontent.com/74207428/146973970-7407cbc4-80b7-497f-9cc7-4ed497b79d92.png)
