### PR TITLE
Feat/032022 html parser UI

### DIFF
--- a/javascript/ace/html-parser.js
+++ b/javascript/ace/html-parser.js
@@ -66,7 +66,7 @@ require(['jquery'], function ($) {
                             fontSize: "12pt",
                             showLineNumbers: true,
                             showGutter: true,
-                            vScrollBarAlwaysVisible:true,
+                            vScrollBarAlwaysVisible: false,
                             enableBasicAutocompletion: true,
                             enableLiveAutocompletion: true
                         });
@@ -91,7 +91,7 @@ require(['jquery'], function ($) {
                             fontSize: "12pt",
                             showLineNumbers: true,
                             showGutter: true,
-                            vScrollBarAlwaysVisible:true,
+                            vScrollBarAlwaysVisible: false,
                             enableBasicAutocompletion: true,
                             enableLiveAutocompletion: true
                         });
@@ -116,7 +116,7 @@ require(['jquery'], function ($) {
                             fontSize: "12pt",
                             showLineNumbers: true,
                             showGutter: true,
-                            vScrollBarAlwaysVisible:true,
+                            vScrollBarAlwaysVisible: false,
                             enableBasicAutocompletion: true,
                             enableLiveAutocompletion: true
                         });

--- a/javascript/ace/html-parser.js
+++ b/javascript/ace/html-parser.js
@@ -62,7 +62,8 @@ require(['jquery'], function ($) {
                     htmlEditor.getSession().setMode("ace/mode/html");
                     ace.config.loadModule('ace/ext/language_tools', function () {
                         htmlEditor.setOptions({
-                            fontSize: "16pt",
+                            fontFamily: 'SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace',
+                            fontSize: "12pt",
                             showLineNumbers: true,
                             showGutter: true,
                             vScrollBarAlwaysVisible:true,
@@ -86,7 +87,8 @@ require(['jquery'], function ($) {
                     cssEditor.getSession().setMode("ace/mode/css");
                     ace.config.loadModule('ace/ext/language_tools', function () {
                         cssEditor.setOptions({
-                            fontSize: "16pt",
+                            fontFamily: 'SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace',
+                            fontSize: "12pt",
                             showLineNumbers: true,
                             showGutter: true,
                             vScrollBarAlwaysVisible:true,
@@ -110,7 +112,8 @@ require(['jquery'], function ($) {
                     jsEditor.getSession().setMode("ace/mode/javascript");
                     ace.config.loadModule('ace/ext/language_tools', function () {
                         jsEditor.setOptions({
-                            fontSize: "16pt",
+                            fontFamily: 'SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace',
+                            fontSize: "12pt",
                             showLineNumbers: true,
                             showGutter: true,
                             vScrollBarAlwaysVisible:true,

--- a/scss/saylor/_html-parser.scss
+++ b/scss/saylor/_html-parser.scss
@@ -1,12 +1,18 @@
   .que.coderunner .ace_editor.html-question {
-      height: 300px;
+      resize: vertical;
+      overflow: hidden;
+      min-height: 200px;
   }
 
   .que.coderunner .ace_editor.css-question {
-      height: 200px;
+      resize: vertical;
+      overflow: hidden;
+      min-height: 200px;
   }
   .que.coderunner .ace_editor.js-question {
-      height: 100px;
+      resize: vertical;
+      overflow: hidden;
+      min-height: 200px;
   }
 
   .que.coderunner .html-parser.coderunner-ui-element {
@@ -15,8 +21,10 @@
 
   .que.coderunner .html-parser.rendered-html {
       width: 100%;
-      min-height: 200px;
+      min-height: 300px;
       border: 1px solid $gray-300;
+      resize: vertical;
+      overflow: hidden;
   }
 
   #editors {


### PR DESCRIPTION
This PR:
1) Updates html-parser questions to a 12pt font size and use the standard SA coding font families.
2) Hides the scrollbar from being visible by default; it appears if the number of lines extends past the editor window.
3) Adds resizing to the editor windows. Editors are also standardized to an initial 200px height so all should fit on a normal 1080p screen.

![image](https://user-images.githubusercontent.com/6720891/161304075-796e0d29-5761-4a9d-8bc6-6d81ef757716.png)
