### PR TITLE
Fix/message nav icon

### DIFF
--- a/templates/navbar.mustache
+++ b/templates/navbar.mustache
@@ -61,7 +61,7 @@
             {{{ output.search_box }}}
         </div>
             <!-- navbar_plugin_output -->
-            <li class="nav-item">
+            <li class="d-flex nav-item">
                 {{{ output.navbar_plugin_output }}}
             </li>
             <!-- user_menu -->


### PR DESCRIPTION
Just added the d-flex class to the nav li. Now icons are side-by-side. 
Closes #346  

![image](https://user-images.githubusercontent.com/74207428/167700725-89a88fdc-c875-4b78-bc87-42cd0b8f7ceb.png)
