### PR TITLE
Move HTML Parser editor resizing to a resizeObserver

### DIFF
--- a/javascript/ace/html-parser.js
+++ b/javascript/ace/html-parser.js
@@ -25,10 +25,6 @@ async function monitorHtmlAreaChange(htmlParser) {
     $(htmlParser).find(".html-parser.html-area").on('change keyup paste input', function () {
         console.info('Registered HTML Parser HTML area change:', $(htmlParser).find(".html-parser.html-area").val());
         renderHtmlParser(htmlParser);
-
-        // Also resize the editor so it fills the full area in case someone has resized.
-        let htmlEditor = ace.edit($(htmlParser).find(".html-question.ace_editor").prop('id'));
-        htmlEditor.resize();
     });
 }
 
@@ -36,10 +32,6 @@ async function monitorCssAreaChange(htmlParser) {
     $(htmlParser).find(".html-parser.css-area").on('change keyup paste input', function () {
         console.info('Registered HTML Parser CSS area change:', $(htmlParser).find(".html-parser.css-area").val());
         renderHtmlParser(htmlParser);
-
-        // Also resize the editor so it fills the full area in case someone has resized.
-        let cssEditor = ace.edit($(htmlParser).find(".css-question.ace_editor").prop('id'));
-        cssEditor.resize();
     });
 }
 
@@ -47,12 +39,15 @@ async function monitorJsAreaChange(htmlParser) {
     $(htmlParser).find(".html-parser.js-area").on('change keyup paste input', function () {
         console.info('Registered HTML Parser JS area change:', $(htmlParser).find(".html-parser.js-area").val());
         renderHtmlParser(htmlParser);
-
-        // Also resize the editor so it fills the full area in case someone has resized.
-        let jsEditor = ace.edit($(htmlParser).find(".js-question.ace_editor").prop('id'));
-        jsEditor.resize();
     });
 }
+
+async function monitorEditorResize(editorElement, callback) {
+  // Create a resizeObserver to monitor when an editor element is resized.
+  var resizeObserver = new ResizeObserver(() => callback() );
+  resizeObserver.observe(editorElement);
+};
+
 
 require(['jquery'], function ($) {
     $(window).on('load', function() {
@@ -146,6 +141,18 @@ require(['jquery'], function ($) {
                     monitorHtmlAreaChange(htmlParser);
                     monitorCssAreaChange(htmlParser);
                     monitorJsAreaChange(htmlParser);
+
+                    // Begin monitoring of the editors and resize the ACE editor if the div element changes size.
+                    monitorEditorResize(document.getElementById($(htmlParser).find(".html-question.ace_editor").prop('id')), function() {
+                        htmlEditor.resize();
+                    });
+                    monitorEditorResize(document.getElementById($(htmlParser).find(".css-question.ace_editor").prop('id')), function() {
+                        cssEditor.resize();
+                    });
+                    monitorEditorResize(document.getElementById($(htmlParser).find(".js-question.ace_editor").prop('id')), function() {
+                        jsEditor.resize();
+                    });
+
                 });
 
             });

--- a/scss/saylor/_html-parser.scss
+++ b/scss/saylor/_html-parser.scss
@@ -64,3 +64,9 @@
 .html-parser-wrapper {
   background: white;
 }
+
+.ace-saylor {
+  .ace_print-margin {
+    width: 0;
+  }
+}


### PR DESCRIPTION
The previous method of resizing the HTML Parser ACE editors did so when there was a change in the editor - meaning when something was typed. This ended up causing issues on some questions where a lot of code was preloaded and the student had to *review* rather than *write* code.

This PR moves the resizing function to using a resizeObserver that fires when the editor div is resized.


Note: odd thing I noticed is that the ACE editor already automatically resizes when the 'window' is resized. Horizontally only.